### PR TITLE
Generalize queueItems to any Foldable

### DIFF
--- a/work-queue/examples/war/best-deck.hs
+++ b/work-queue/examples/war/best-deck.hs
@@ -65,7 +65,7 @@ runRound queue gen players = do
 
     let items = flip V.imap players $ \j player ->
             (player, \s -> VM.unsafeWrite scores j (s, player))
-    atomically $ queueItems queue $ V.toList items
+    atomically $ queueItems queue items
     atomically $ checkEmptyWorkQueue queue
 
     -- Sort the vector by score


### PR DESCRIPTION
As discussed on Slack. I decided to use Foldable instead of
MonoFoldable, since the type signature is easier to use, and it's
incredibly unlikely that there are data types that would be monomorphic
and allow holding a tuple including a function.
