### PR TITLE
Get everything compiling with GHC 7.10.2/LTS-3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cabal.config
 .shake.*
 .docker-sandbox
 .eventlog
+.stack-work/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,6 @@
-resolver: lts-2.16
+resolver: lts-3.0
 extra-deps:
-  - concrete-typerep-0.1.0.2
-  - monad-extras-0.5.9
-flags:
-  concrete-typerep:
-    new-typerep: true
+  - hybrid-vectors-0.2
 packages:
   - ./json-conduit
   - ./redis-fp

--- a/work-queue/src/Data/ConcreteTypeRep.hs
+++ b/work-queue/src/Data/ConcreteTypeRep.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving, CPP #-}
+
+{- |
+This module defines 'Binary' and 'Hashable' instances for 'TypeRep'. These are defined on a newtype of 'TypeRep', namely 'ConcreteTypeRep', for two purposes:
+
+  * to avoid making orphan instances
+
+  * the 'Hashable' instance for 'ConcreteTypeRep' may not be pure enough for some people's tastes.
+
+As usual with 'Typeable', this module will typically be used with some variant of @Data.Dynamic@. Two possible uses of this module are:
+
+  * making hashmaps: @HashMap 'ConcreteTypeRep' Dynamic@
+
+  * serializing @Dynamic@s.
+
+-}
+
+module Data.ConcreteTypeRep (
+  ConcreteTypeRep,
+  cTypeOf,
+  toTypeRep,
+  fromTypeRep,
+ ) where
+
+import Data.Typeable
+#if MIN_VERSION_base(4, 4, 0)
+import Data.Typeable.Internal
+import GHC.Fingerprint.Type
+#endif
+
+import Data.Hashable
+import Data.Binary
+
+import System.IO.Unsafe
+
+import Control.Applicative((<$>))
+
+-- | Abstract type providing the functionality of 'TypeRep', but additionally supporting hashing and serialization.
+--
+-- The 'Eq' instance is just the 'Eq' instance for 'TypeRep', so an analogous guarantee holds: @'cTypeOf' a == 'cTypeOf' b@ if and only if @a@ and @b@ have the same type.
+-- The hashing and serialization functions preserve this equality.
+newtype ConcreteTypeRep = CTR { unCTR :: TypeRep } deriving(Eq, Typeable)
+
+-- | \"Concrete\" version of 'typeOf'.
+cTypeOf :: Typeable a => a -> ConcreteTypeRep
+cTypeOf = fromTypeRep . typeOf
+
+-- | Converts to the underlying 'TypeRep'
+toTypeRep :: ConcreteTypeRep -> TypeRep
+toTypeRep = unCTR
+
+-- | Converts from the underlying 'TypeRep'
+fromTypeRep :: TypeRep -> ConcreteTypeRep
+fromTypeRep = CTR
+
+-- show as a normal TypeRep
+instance Show ConcreteTypeRep where
+  showsPrec i = showsPrec i . unCTR
+
+
+-- | This instance is guaranteed to be consistent for a single run of the program, but not for multiple runs.
+instance Hashable ConcreteTypeRep where
+#if MIN_VERSION_base(4,8,0)
+  hashWithSalt salt (CTR (TypeRep (Fingerprint w1 w2) _ _ _)) = salt `hashWithSalt` w1 `hashWithSalt` w2
+#elif MIN_VERSION_base(4, 4, 0)
+  hashWithSalt salt (CTR (TypeRep (Fingerprint w1 w2) _ _)) = salt `hashWithSalt` w1 `hashWithSalt` w2
+#else
+  hashWithSalt salt ctr = hashWithSalt salt (unsafePerformIO . typeRepKey . toTypeRep $ ctr)
+#endif
+
+------------- serialization: this uses Gökhan San's construction, from
+---- http://www.mail-archive.com/haskell-cafe@haskell.org/msg41134.html
+toTyConRep :: TyCon -> TyConRep
+fromTyConRep :: TyConRep -> TyCon
+#if MIN_VERSION_base(4, 4, 0)
+type TyConRep = (String, String, String)
+toTyConRep (TyCon _ pack mod name) = (pack, mod, name)
+fromTyConRep (pack, mod, name) = mkTyCon3 pack mod name
+#else
+type TyConRep = String
+toTyConRep = tyConString
+fromTyConRep = mkTyCon
+#endif
+
+newtype SerialRep = SR (TyConRep, [SerialRep]) deriving(Binary)
+
+toSerial :: ConcreteTypeRep -> SerialRep
+toSerial (CTR t) =
+  case splitTyConApp t of
+    (con, args) -> SR (toTyConRep con, map (toSerial . CTR) args)
+
+fromSerial :: SerialRep -> ConcreteTypeRep
+fromSerial (SR (con, args)) = CTR $ mkTyConApp (fromTyConRep con) (map (unCTR . fromSerial) args)
+
+instance Binary ConcreteTypeRep where
+  put = put . toSerial
+  get = fromSerial <$> get

--- a/work-queue/src/Distributed/WorkQueue.hs
+++ b/work-queue/src/Distributed/WorkQueue.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE ConstraintKinds  #-}
 {-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TypeFamilies     #-}
 -- | Distribute a "Data.WorkQueue" queue over a network via
 -- "Data.Streaming.NetworkMessage".
 --

--- a/work-queue/test/Distributed/WorkQueueSpec.hs
+++ b/work-queue/test/Distributed/WorkQueueSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
@@ -20,9 +21,9 @@ import           Distributed.RedisQueue
 import           Distributed.WorkQueue
 import           FP.Redis (Seconds(..), connectInfo)
 import           FP.ThreadFileLogger
-import           Filesystem (isFile, removeFile)
 import qualified Network.Socket as NS
 import           Prelude (appendFile, read)
+import           System.Directory (doesFileExist, removeFile)
 import           System.Environment (withArgs)
 import           System.Environment.Executable (getExecutablePath)
 import           System.Exit (ExitCode(ExitSuccess))
@@ -284,7 +285,7 @@ waitForSocket = loop (100 :: Int)
 -- Remove the specified file, if it exists.
 removeFileIfExists :: FilePath -> IO ()
 removeFileIfExists fp = do
-    exists <- isFile fp
+    exists <- doesFileExist fp
     when exists $ removeFile fp
 
 type Process = Either ProcessHandle (Async ())

--- a/work-queue/work-queue.cabal
+++ b/work-queue/work-queue.cabal
@@ -35,10 +35,12 @@ library
                        Control.Exception.Mask
   other-modules:       Distributed.JobQueue.Shared
                        Distributed.JobQueue.Heartbeat
+                       Data.ConcreteTypeRep
   build-depends:       base
                      , async
                      , binary
                      , classy-prelude
+                     , hashable
                      , lifted-base
                      , monad-control
                      , retry
@@ -50,7 +52,6 @@ library
                      , void
                      , mono-traversable
                      , transformers
-                     , concrete-typerep
                      , bytestring
                      , redis-fp
                      , executable-hash >= 0.2.0.0
@@ -146,7 +147,7 @@ test-suite test
                      , unix
                      , split
                      , classy-prelude
-                     , system-fileio
+                     , directory
                      , executable-path
                      , process
                      , silently


### PR DESCRIPTION
The tests for job-queue currently fail, which should be fixed before
merging.

@mgsloan Can you look into the test failures? I'm seeing things like:

```
Failures:

  test/Data/Streaming/NetworkMessageSpec.hs:36:
  1) Data.Streaming.NetworkMessage can yield a value from the client
       uncaught exception: NetworkMessageException (NMConnectionClosed)

  test/Distributed/JobQueueSpec.hs:130:
  2) Distributed.JobQueue Doesn't lose data when master fails
       uncaught exception: IOException of type UserError (user error (Timed out waiting for value))

  test/Distributed/JobQueueSpec.hs:130:
  3) Distributed.JobQueue Works despite clients and workers being started and killed periodically
       uncaught exception: IOException of type UserError (user error (Didn't send any requests.))
```

Pinging @borsboom 
