### PR TITLE
work-queue: Pass `RequestId` to worker.

### DIFF
--- a/work-queue/examples/redis/redis.hs
+++ b/work-queue/examples/redis/redis.hs
@@ -45,7 +45,7 @@ masterOrSlave =
     calc input = do
         threadDelay (1000 * 1000 * 2)
         return $ foldl' xor zeroBits (input :: [Int])
-    inner redis mci request queue = do
+    inner redis mci _requestId request queue = do
         requestSlave redis mci
         subresults <- mapQueue queue request
         response <- calc (otoList (subresults :: Vector Int))

--- a/work-queue/test/Distributed/WorkQueueSpec.hs
+++ b/work-queue/test/Distributed/WorkQueueSpec.hs
@@ -216,8 +216,8 @@ runMasterOrSlave RedisConfig {..} | isThreadDelay = runThreadFileLoggingT $ do
             threadDelay (x * 1000)
             return 0
         calc _ = return 0
-        inner :: RedisInfo -> MasterConnectInfo -> Vector [Int] -> WorkQueue [Int] Int -> IO Int
-        inner redis mci request queue = do
+        inner :: RedisInfo -> MasterConnectInfo -> RequestId -> Vector [Int] -> WorkQueue [Int] Int -> IO Int
+        inner redis mci _requestId request queue = do
             requestSlave redis mci
             results <- mapQueue queue request
             if results == fmap (\_ -> 0) request
@@ -231,8 +231,8 @@ runMasterOrSlave RedisConfig {..} = runThreadFileLoggingT $ do
     [lslaves] <- liftIO getArgs
     let calc :: [Int] -> IO Int
         calc input =  return $ foldl' xor zeroBits input
-        inner :: RedisInfo -> MasterConnectInfo -> Vector [Int] -> WorkQueue [Int] Int -> IO Int
-        inner redis mci request queue = do
+        inner :: RedisInfo -> MasterConnectInfo -> RequestId -> Vector [Int] -> WorkQueue [Int] Int -> IO Int
+        inner redis mci _requestId request queue = do
             requestSlave redis mci
             subresults <- mapQueue queue request
             liftIO $ calc (otoList (subresults :: Vector Int))


### PR DESCRIPTION
I need this to cleanly implement proper logging in `smart-device-sw`.
