### PR TITLE
Remove `uuid` constraint

### DIFF
--- a/work-queue/work-queue.cabal
+++ b/work-queue/work-queue.cabal
@@ -72,7 +72,7 @@ library
                      , transformers-base
                      , unix
                      , unordered-containers
-                     , uuid >= 1.3.12
+                     , uuid
                      , vector
                      , void
                      , lifted-async


### PR DESCRIPTION
Since `work-queue` _can_ use older `uuid`, this removes the constraint on `uuid` which makes things easier for building patched lts-3.13 images.
